### PR TITLE
Updated "rom_file" as a mandatory argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,6 @@ const FREQUENCY: u32 = 4194304;
 #[clap(author, version, about, long_about = None)]
 struct Args {
     /// GameBoy ROM file to input
-    #[clap(short, long)]
     rom_file: String,
 
     /// Toggle sleeping between frames


### PR DESCRIPTION
I think it makes more sense to do `feboy my_rom.gb` instead of `feboy --rom-name my_rom.gb`